### PR TITLE
jailed process

### DIFF
--- a/GHCiOnline.cabal
+++ b/GHCiOnline.cabal
@@ -49,5 +49,6 @@ Executable GHCiOnline
                    snap-core >= 0.9,
                    snap-server >= 0.9,
                    text >= 0.11,
-                   unordered-containers > 0.2
+                   unordered-containers > 0.2,
+                   cjail >= 0.1
 


### PR DESCRIPTION
- Jail processes. On  hs15, the jail should be changed from `/tmp/jail` to `/home/hs15/cjail/ghci-online-jail`.
- Uses: https://github.com/scslab/cjail
- Set memory limit `echo 1073741824 >  /cgroup/cjail/memory.limit_in_bytes`
